### PR TITLE
修复window中path绝对路径被转义，导致无法require的情况

### DIFF
--- a/src/webpack/doc-scripts-entry.js
+++ b/src/webpack/doc-scripts-entry.js
@@ -21,6 +21,10 @@ module.exports = function(options) {
 
   ReactDocRenderer = ReactDocRenderer.__esModule ? ReactDocRenderer.default : ReactDocRenderer
 
+  options.docs = options.docs.map((tPath)=>{
+    return tPath.replace(/\\/g,"/");
+  });
+
   var docs = [
     ${options.docs
       .map(path => {


### PR DESCRIPTION
修复window中path绝对路径被转义，导致无法require的情况